### PR TITLE
Optimising pathfinding

### DIFF
--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -148,8 +148,9 @@ public class Character : IXmlSerializable, ISelectable
         // NOTE: We might not be pathing to it right away (due to 
         // requiring materials), but we still need to verify that the
         // final location can be reached.
-
+        Profiler.BeginSample("PathGeneration");
         pathAStar = new Path_AStar(World.current, CurrTile, DestTile);	// This will calculate a path from curr to dest.
+        Profiler.EndSample();
         if (pathAStar.Length() == 0)
         {
             Debug.LogError("Path_AStar returned no path to target job tile!");

--- a/Assets/Scripts/Models/Character.cs
+++ b/Assets/Scripts/Models/Character.cs
@@ -374,7 +374,7 @@ public class Character : IXmlSerializable, ISelectable
 
             if (NextTile == CurrTile)
             {
-                Debug.LogError("Update_DoMovement - nextTile is currTile?");
+                //Debug.LogError("Update_DoMovement - nextTile is currTile?");
             }
         }
 

--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -654,7 +654,11 @@ public class Furniture : IXmlSerializable, ISelectable
             Room.DoRoomFloodFill(this.tile);
         }
 
-        World.current.InvalidateTileGraph();
+        //World.current.InvalidateTileGraph();
+        if (World.current.tileGraph != null)
+        {
+            World.current.tileGraph.RegenerateGraphAtTile(tile);
+        }
 
         // At this point, no DATA structures should be pointing to us, so we
         // should get garbage-collected.

--- a/Assets/Scripts/Models/World.cs
+++ b/Assets/Scripts/Models/World.cs
@@ -468,7 +468,11 @@ public class World : IXmlSerializable
                 // buy the furniture's movement cost, a furniture movement cost
                 // of exactly 1 doesn't impact our pathfinding system, so we can
                 // occasionally avoid invalidating pathfinding graphs
-                InvalidateTileGraph();	// Reset the pathfinding system
+                //InvalidateTileGraph();	// Reset the pathfinding system
+                if (tileGraph != null)
+                {
+                    tileGraph.RegenerateGraphAtTile(t);
+                }
             }
         }
 
@@ -492,6 +496,7 @@ public class World : IXmlSerializable
     {
         tileGraph = null;
     }
+
 
     public bool IsFurniturePlacementValid(string furnitureType, Tile t)
     {

--- a/Assets/Scripts/Models/World.cs
+++ b/Assets/Scripts/Models/World.cs
@@ -487,7 +487,11 @@ public class World : IXmlSerializable
 		
         cbTileChanged(t);
 
-        InvalidateTileGraph();
+        //InvalidateTileGraph();
+        if (tileGraph != null)
+        {
+            tileGraph.RegenerateGraphAtTile(t);
+        }
     }
 
     // This should be called whenever a change to the world

--- a/Assets/Scripts/Pathfinding/Path_Node.cs
+++ b/Assets/Scripts/Pathfinding/Path_Node.cs
@@ -14,5 +14,4 @@ public class Path_Node<T>
     public Path_Edge<T>[] edges;
     // Nodes leading OUT from this node.
 
-
 }

--- a/Assets/Scripts/Pathfinding/Path_TileGraph.cs
+++ b/Assets/Scripts/Pathfinding/Path_TileGraph.cs
@@ -50,40 +50,45 @@ public class Path_TileGraph
         // Now loop through all nodes again
         // Create edges for neighbours
 
-        int edgeCount = 0;
 
         foreach (Tile t in nodes.Keys)
         {
-            Path_Node<Tile> n = nodes[t];
-
-            List<Path_Edge<Tile>> edges = new List<Path_Edge<Tile>>();
-
-            // Get a list of neighbours for the tile
-            Tile[] neighbours = t.GetNeighbours(true);	// NOTE: Some of the array spots could be null.
-
-            // If neighbour is walkable, create an edge to the relevant node.
-            for (int i = 0; i < neighbours.Length; i++)
-            {
-                if (neighbours[i] != null && neighbours[i].movementCost > 0 && IsClippingCorner(t, neighbours[i]) == false)
-                {
-                    // This neighbour exists, is walkable, and doesn't requiring clipping a corner --> so create an edge.
-
-                    Path_Edge<Tile> e = new Path_Edge<Tile>();
-                    e.cost = neighbours[i].movementCost;
-                    e.node = nodes[neighbours[i]];
-
-                    // Add the edge to our temporary (and growable!) list
-                    edges.Add(e);
-
-                    edgeCount++;
-                }
-            }
-
-            n.edges = edges.ToArray();
+            GenerateEdgesByTile(t);
         }
 
-        Debug.Log("Path_TileGraph: Created " + edgeCount + " edges.");
 
+    }
+
+    void GenerateEdgesByTile(Tile t)
+    {
+        Path_Node<Tile> n = nodes[t];
+        List<Path_Edge<Tile>> edges = new List<Path_Edge<Tile>>();
+        // Get a list of neighbours for the tile
+        Tile[] neighbours = t.GetNeighbours(true);
+        // NOTE: Some of the array spots could be null.
+        // If neighbour is walkable, create an edge to the relevant node.
+        for (int i = 0; i < neighbours.Length; i++)
+        {
+            if (neighbours[i] != null && neighbours[i].movementCost > 0 && IsClippingCorner(t, neighbours[i]) == false)
+            {
+                // This neighbour exists, is walkable, and doesn't requiring clipping a corner --> so create an edge.
+                Path_Edge<Tile> e = new Path_Edge<Tile>();
+                e.cost = neighbours[i].movementCost;
+                e.node = nodes[neighbours[i]];
+                // Add the edge to our temporary (and growable!) list
+                edges.Add(e);
+            }
+        }
+        n.edges = edges.ToArray();
+    }
+
+    public void RegenerateGraphAtTile(Tile changedTile)
+    {
+        GenerateEdgesByTile(changedTile);
+        foreach (Tile tile in changedTile.GetNeighbours(true))
+        {
+            GenerateEdgesByTile(tile);
+        }
     }
 
     bool IsClippingCorner(Tile curr, Tile neigh)


### PR DESCRIPTION
Regenerates the pathfinding graph around the point that has been modified rather than deleting the entire graph. Makes pathfinding after having constructed take around 40 ms rather than 3000 ms on my machine.

Fixes #64
